### PR TITLE
add redirect to edit handler for new view pages

### DIFF
--- a/wiki.go
+++ b/wiki.go
@@ -34,7 +34,10 @@ func renderTemplate(w http.ResponseWriter, tpl string, p *Page) {
 
 func viewHandler(w http.ResponseWriter, r *http.Request) {
 	title := r.URL.Path[len("/view/"):]
-	p, _ := loadPage(title)
+	p, err := loadPage(title)
+	if err != nil {
+		http.Redirect(w, r, "/edit/"+title, http.StatusFound)
+	}
 	renderTemplate(w, "view", p)
 }
 

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -70,6 +70,19 @@ func TestViewHandler(t *testing.T) {
 	}
 }
 
+func TestViewHandlerRedirect(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://localhost/view/unknown", nil)
+	w := httptest.NewRecorder()
+	viewHandler(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("received a %v when I expected a %v", resp.StatusCode, http.StatusFound)
+	}
+	if url, _ := resp.Location(); url.Path != "/edit/unknown" {
+		t.Errorf("unexpected path -- got %v when I wanted /edit/unknown", url.Path)
+	}
+}
+
 func TestRootHandler(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://localhost/", nil)
 	genericErrorHandler(t, err)


### PR DESCRIPTION
if hitting an unknown path from `/view/` the app will redirect to the edit handler